### PR TITLE
Update/version 4.3.3

### DIFF
--- a/HEADER
+++ b/HEADER
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 dc-square GmbH
+ * Copyright 2020 HiveMQ GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 dc-square GmbH
+   Copyright 2020 HiveMQ GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.adoc
+++ b/README.adoc
@@ -17,7 +17,7 @@ A new HiveMQ extension project can be created by running the following maven com
 
 [source,bash]
 ----
-mvn archetype:generate -DarchetypeGroupId=com.hivemq -DarchetypeArtifactId=hivemq-extension-archetype -DarchetypeVersion=4.3.0
+mvn archetype:generate -DarchetypeGroupId=com.hivemq -DarchetypeArtifactId=hivemq-extension-archetype -DarchetypeVersion=4.3.3
 ----
 
 === Maven Repository

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.hivemq</groupId>
     <artifactId>hivemq-extension-archetype</artifactId>
-    <version>4.3.2</version>
+    <version>4.3.3</version>
     <packaging>maven-archetype</packaging>
 
     <name>HiveMQ 4 Extension Archetype</name>
@@ -27,6 +27,12 @@
         <developer>
             <name>Florian Limpöck</name>
             <email>florian.limpoeck@hivemq.com</email>
+            <organization>HiveMQ GmbH</organization>
+            <organizationUrl>http://www.hivemq.com</organizationUrl>
+        </developer>
+        <developer>
+            <name>Yannick Weber</name>
+            <email>yannick.weber@hivemq.com</email>
             <organization>HiveMQ GmbH</organization>
             <organizationUrl>http://www.hivemq.com</organizationUrl>
         </developer>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>com.hivemq</groupId>
     <artifactId>hivemq-extension-archetype</artifactId>
-    <version>4.3.0</version>
+    <version>4.3.2</version>
     <packaging>maven-archetype</packaging>
 
     <name>HiveMQ 4 Extension Archetype</name>

--- a/pom.xml
+++ b/pom.xml
@@ -19,16 +19,16 @@
     <inceptionYear>2018</inceptionYear>
 
     <organization>
-        <name>dc-square GmbH</name>
-        <url>http://www.dc-square.de</url>
+        <name>HiveMQ GmbH</name>
+        <url>http://www.hivemq.com</url>
     </organization>
 
     <developers>
         <developer>
             <name>Florian Limpöck</name>
-            <email>florian.limpoeck@dc-square.de</email>
-            <organization>dc-square GmbH</organization>
-            <organizationUrl>http://www.dc-square.de</organizationUrl>
+            <email>florian.limpoeck@hivemq.com</email>
+            <organization>HiveMQ GmbH</organization>
+            <organizationUrl>http://www.hivemq.com</organizationUrl>
         </developer>
     </developers>
 

--- a/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -21,6 +21,12 @@
         <include>**/*.xml</include>
       </includes>
     </fileSet>
+    <fileSet filtered="true" packaged="true" encoding="UTF-8">
+      <directory>src/test/java</directory>
+      <includes>
+        <include>**/*.java</include>
+      </includes>
+    </fileSet>
     <fileSet filtered="true" encoding="UTF-8">
       <directory></directory>
       <includes>

--- a/src/main/resources/archetype-resources/LICENSE.txt
+++ b/src/main/resources/archetype-resources/LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2018 dc-square GmbH
+   Copyright 2020 HiveMQ GmbH
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/main/resources/archetype-resources/README.adoc
+++ b/src/main/resources/archetype-resources/README.adoc
@@ -4,19 +4,22 @@
 :hivemq-blog-tools: http://www.hivemq.com/mqtt-toolbox
 :maven-documentation-profile-link: http://maven.apache.org/guides/introduction/introduction-to-profiles.html
 :hivemq-support: http://www.hivemq.com/support/
+:hivemq-testcontainer: https://github.com/hivemq/hivemq-testcontainer
+:hivemq-mqtt-client: https://github.com/hivemq/hivemq-mqtt-client
 
 == HiveMQ 4 Hello World Extension
 
 *Type*: Demonstration Extension
 
-*Version*: 4.3.0
+*Version*: 4.3.3
 
 *License*: Apache License Version 2.0
 
 === Purpose
 
 This Hello World extension sets a ClientLifecycleEventListener which logs
-the MQTT Version and identifier of every connecting and disconnecting client.
+the MQTT Version and identifier of every connecting and disconnecting client and
+registers a PublishInboundInterceptor to modify the payload of every Publish with the topic 'hello/world' to 'Hello World!'.
 
 There is {hivemq-extension-docs-archetype-link}[a Maven Archetype available]
 to generate a basic extension from the IDE.
@@ -28,13 +31,22 @@ to grasp the core concepts of HiveMQ extension development.
 
 . Clone this repository into a Java 11 maven project.
 . Run `mvn package` goal from Maven to build the extension.
-. Move the file: "target/hivemq-hello-world-extension-4.3.0-distribution.zip" to the directory: "HIVEMQ_HOME/extensions"
+. Move the file: "target/hivemq-hello-world-extension-4.3.3-distribution.zip" to the directory: "HIVEMQ_HOME/extensions"
 . Unzip the file.
 . Start HiveMQ.
 
 === First Steps
 
+==== Manual Testing
+
 Connect with an {hivemq-blog-tools}[MQTT client] of your choice. You should see a log message with its identifier and MQTT version.
+
+==== Automatic Testing
+
+Execute the `HelloWorldInterceptorIT` for automatic testing of the extension.
+It uses the {hivemq-testcontainer}[HiveMQ Testcontainer] to automatically package, deploy and run the extension inside a HiveMQ docker container.
+The test creates a {hivemq-mqtt-client}[HiveMQ MQTT Client] to publish and receive a message with the topic 'hello/world'.
+It checks whether the payload has been changed correctly to 'Hello World!'.
 
 === Next steps
 

--- a/src/main/resources/archetype-resources/assembly.xml
+++ b/src/main/resources/archetype-resources/assembly.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
- ~ Copyright 2018 dc-square GmbH
+ ~ Copyright 2020 HiveMQ GmbH
  ~
  ~  Licensed under the Apache License, Version 2.0 (the "License");
  ~  you may not use this file except in compliance with the License.

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -37,7 +37,38 @@
         <dependency>
             <groupId>com.hivemq</groupId>
             <artifactId>hivemq-extension-sdk</artifactId>
-            <version>4.3.2</version>
+            <version>4.3.0</version>
+        </dependency>
+        <!-- testing -->
+        <dependency>
+            <groupId>com.hivemq</groupId>
+            <artifactId>hivemq-mqtt-client</artifactId>
+            <version>1.2.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.6.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.6.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.hivemq</groupId>
+            <artifactId>hivemq-testcontainer-junit5</artifactId>
+            <version>1.1.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.3</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -37,7 +37,7 @@
         <dependency>
             <groupId>com.hivemq</groupId>
             <artifactId>hivemq-extension-sdk</artifactId>
-            <version>4.3.0</version>
+            <version>4.3.2</version>
         </dependency>
     </dependencies>
 

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright 2018 dc-square GmbH
+  ~ Copyright 2020 HiveMQ GmbH
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@
 
     <properties>
         <extension.name>Hello World Extension</extension.name>
-        <extension.author>dc-square GmbH</extension.author>
+        <extension.author>HiveMQ GmbH</extension.author>
         <asciidoctor.version>1.5.2.1</asciidoctor.version>
         <output.dir>${basedir}</output.dir>
         <source.document.name>README.adoc</source.document.name>

--- a/src/main/resources/archetype-resources/src/main/java/HelloWorldInterceptor.java
+++ b/src/main/resources/archetype-resources/src/main/java/HelloWorldInterceptor.java
@@ -1,0 +1,47 @@
+
+/*
+ * Copyright 2020 HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hivemq;
+
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.extension.sdk.api.interceptor.publish.PublishInboundInterceptor;
+import com.hivemq.extension.sdk.api.interceptor.publish.parameter.PublishInboundInput;
+import com.hivemq.extension.sdk.api.interceptor.publish.parameter.PublishInboundOutput;
+import com.hivemq.extension.sdk.api.packets.publish.ModifiablePublishPacket;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * This is a very simple {@link PublishInboundInterceptor},
+ * it changes the payload of every incoming PUBLISH with the topic 'hello/world' to 'Hello World!'.
+ *
+ * @author Yannick Weber
+ * @since 4.3.3
+ */
+public class HelloWorldInterceptor implements PublishInboundInterceptor {
+
+    @Override
+    public void onInboundPublish(final @NotNull PublishInboundInput publishInboundInput, final @NotNull PublishInboundOutput publishInboundOutput) {
+        final ModifiablePublishPacket publishPacket = publishInboundOutput.getPublishPacket();
+        if ("hello/world".equals(publishPacket.getTopic())) {
+            final ByteBuffer payload = ByteBuffer.wrap("Hello World!".getBytes(StandardCharsets.UTF_8));
+            publishPacket.setPayload(payload);
+        }
+    }
+
+}

--- a/src/main/resources/archetype-resources/src/main/java/HelloWorldListener.java
+++ b/src/main/resources/archetype-resources/src/main/java/HelloWorldListener.java
@@ -2,7 +2,7 @@
 #set( $symbol_dollar = '$' )
 #set( $symbol_escape = '\' )
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2020 HiveMQ GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/archetype-resources/src/main/java/HelloWorldMain.java
+++ b/src/main/resources/archetype-resources/src/main/java/HelloWorldMain.java
@@ -3,7 +3,7 @@
 #set( $symbol_escape = '\' )
 
 /*
- * Copyright 2018 dc-square GmbH
+ * Copyright 2020 HiveMQ GmbH
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/resources/archetype-resources/src/main/java/HelloWorldMain.java
+++ b/src/main/resources/archetype-resources/src/main/java/HelloWorldMain.java
@@ -25,6 +25,7 @@ import com.hivemq.extension.sdk.api.annotations.NotNull;
 import com.hivemq.extension.sdk.api.events.EventRegistry;
 import com.hivemq.extension.sdk.api.parameter.*;
 import com.hivemq.extension.sdk.api.services.Services;
+import com.hivemq.extension.sdk.api.services.intializer.InitializerRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,7 @@ public class HelloWorldMain implements ExtensionMain {
         try {
 
             addClientLifecycleEventListener();
+            addPublishModifier();
 
             final ExtensionInformation extensionInformation = extensionStartInput.getExtensionInformation();
             log.info("Started " + extensionInformation.getName() + ":" + extensionInformation.getVersion());
@@ -72,6 +74,14 @@ public class HelloWorldMain implements ExtensionMain {
 
         eventRegistry.setClientLifecycleEventListener(input -> helloWorldListener);
 
+    }
+
+    private void addPublishModifier() {
+        final InitializerRegistry initializerRegistry = Services.initializerRegistry();
+
+        final HelloWorldInterceptor helloWorldInterceptor = new HelloWorldInterceptor();
+
+        initializerRegistry.setClientInitializer((initializerInput, clientContext) -> clientContext.addPublishInboundInterceptor(helloWorldInterceptor));
     }
 
 }

--- a/src/main/resources/archetype-resources/src/main/resources/hivemq-extension.xml
+++ b/src/main/resources/archetype-resources/src/main/resources/hivemq-extension.xml
@@ -1,7 +1,7 @@
 #set($dollar = '$')
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
- ~ Copyright 2018 dc-square GmbH
+ ~ Copyright 2020 HiveMQ GmbH
  ~
  ~  Licensed under the Apache License, Version 2.0 (the "License");
  ~  you may not use this file except in compliance with the License.

--- a/src/main/resources/archetype-resources/src/test/java/HelloWorldInterceptorIT.java
+++ b/src/main/resources/archetype-resources/src/test/java/HelloWorldInterceptorIT.java
@@ -1,0 +1,74 @@
+#set( $symbol_pound = '#' )
+#set( $symbol_dollar = '$' )
+#set( $symbol_escape = '\' )
+
+/*
+ * Copyright 2020 HiveMQ GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ${package};
+
+import com.hivemq.client.mqtt.MqttGlobalPublishFilter;
+import com.hivemq.client.mqtt.datatypes.MqttQos;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5BlockingClient;
+import com.hivemq.client.mqtt.mqtt5.Mqtt5Client;
+import com.hivemq.client.mqtt.mqtt5.message.publish.Mqtt5Publish;
+import com.hivemq.extension.sdk.api.annotations.NotNull;
+import com.hivemq.testcontainer.core.MavenHiveMQExtensionSupplier;
+import com.hivemq.testcontainer.junit5.HiveMQTestContainerExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * This tests the functionality of the {@link HelloWorldInterceptor}.
+ * It uses the HiveMQ Testcontainer to automatically package and deploy this extension inside a HiveMQ docker container.
+ *
+ * @author Yannick Weber
+ * @since 4.3.3
+ */
+class HelloWorldInterceptorIT {
+
+    @RegisterExtension
+    public final @NotNull HiveMQTestContainerExtension extension =
+            new HiveMQTestContainerExtension()
+                    .withExtension(MavenHiveMQExtensionSupplier.direct().get());
+
+    @Test
+    void test_payload_modified() throws InterruptedException {
+        final Mqtt5BlockingClient client = Mqtt5Client.builder()
+                .identifier("hello-world-client")
+                .serverHost("localhost")
+                .serverPort(extension.getMqttPort())
+                .buildBlocking();
+        client.connect();
+
+        final Mqtt5BlockingClient.Mqtt5Publishes publishes = client.publishes(MqttGlobalPublishFilter.ALL);
+        client.subscribeWith()
+                .topicFilter("hello/world")
+                .qos(MqttQos.EXACTLY_ONCE)
+                .send();
+
+        client.publishWith().topic("hello/world").payload("Good Bye World!".getBytes(StandardCharsets.UTF_8)).send();
+
+        final Mqtt5Publish receive = publishes.receive();
+        assertTrue(receive.getPayload().isPresent());
+        assertEquals("Hello World!", new String(receive.getPayloadAsBytes(), StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
Changed 'dc-square' to 'HiveMQ'
added HelloWorldInterceptor and a corresponding integration test using the HiveMQ Testcontainer and the HiveMQ MQTT client.

Do not merge before the release of the HiveMQ Testcontainer 1.1.0. 