### PR TITLE
[CI CD] direct maven central publish 4.4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,9 @@
 name: Publish to Maven Central
 
 on:
-  create:
-    tags:
-      - '*'
+  release:
+    types:
+      - created
 
 jobs:
   build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,27 @@
+name: Publish to Maven Central
+
+on:
+  create:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+      - name: setup java
+        uses: actions/setup-java@v1
+        with:
+          java-version: "11"
+      - name: setup maven server
+        uses: s4u/maven-settings-action@v2.4.0
+        with:
+          servers: '[{"id": "ossrh", "username": "${{ secrets.SONATYPE_USERNAME }}", "password": "${{ secrets.SONATYPE_PASSWORD }}"}]'
+      - name: Publish to Maven Central
+        env:
+          SIGN_KEY: ${{ secrets.SIGN_KEY }}
+          SIGN_KEY_PASS: ${{ secrets.SIGN_KEY_PASS }}
+        run: mvn clean package -Dmaven.test.skip=true sign:sign deploy -B
+

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,11 @@
         </developer>
     </developers>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <sonatype.server>https://oss.sonatype.org/</sonatype.server>
+    </properties>
+
     <build>
         <plugins>
             <plugin>
@@ -84,16 +89,38 @@
                     <artifactId>maven-archetype-plugin</artifactId>
                     <version>2.4</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.simplify4u.plugins</groupId>
+                    <artifactId>sign-maven-plugin</artifactId>
+                    <version>0.3.0</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>sign</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.6.7</version>
+                    <extensions>true</extensions>
+                    <configuration>
+                        <serverId>ossrh</serverId>
+                        <nexusUrl>${sonatype.server}</nexusUrl>
+                        <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>
 
     <distributionManagement>
-        <repository>
-            <id>bintray-hivemq-HiveMQ-hivemq-maven-extension-archetype</id>
-            <name>hivemq-HiveMQ-hivemq-maven-extension-archetype</name>
-            <url>https://api.bintray.com/maven/hivemq/HiveMQ/hivemq-maven-extension-archetype</url>
-        </repository>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>${sonatype.server}content/repositories/snapshots</url>
+        </snapshotRepository>
     </distributionManagement>
 
     <licenses>

--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -169,7 +169,7 @@
                     <plugin>
                         <groupId>com.hivemq</groupId>
                         <artifactId>hivemq-maven-plugin</artifactId>
-                        <version>4.0.2</version>
+                        <version>4.0.3</version>
                         <executions>
                             <execution>
                                 <id>hivemq</id>


### PR DESCRIPTION
- added GitHub Actions workflow to automatically publish to maven central upon creating a GitHub release. 
- hivemq-maven-plugin version to 4.0.3